### PR TITLE
Update loading handling in PracticeStats

### DIFF
--- a/src/routes/PracticeStats/PracticeStats.js
+++ b/src/routes/PracticeStats/PracticeStats.js
@@ -309,9 +309,17 @@ const PracticeStats = () => {
         practice2Stats.length === 0 &&
         practice3Stats.length === 0 ? (
           <p>Select year and country in order to see practice results</p>
-        ) : (
+        ) : (practiceStatsLoading ? ( 
           <>
-            <PracticeContainer>
+            <PracticeTitle>Loading practice stats...</PracticeTitle>
+            <LinearProgress
+              color="secondary"
+              sx={styles.circularProgress}
+            />
+          </>
+          ) : ( 
+          <>
+            {practice1Stats.length > 0 && (<PracticeContainer>
               <PracticeTitle>Practice 1</PracticeTitle>
 
               {Object.keys(practice1TimePeriod).length > 0 && (
@@ -322,38 +330,29 @@ const PracticeStats = () => {
                 <PracticeWeather practiceWeather={practice1Weather} />
               )}
 
-              {practiceStatsLoading && (
-                <LinearProgress
-                  color="secondary"
-                  sx={styles.circularProgress}
-                />
-              )}
-
-              {practice1Stats.length > 0 && (
-                <TableContainer
-                  sx={isDesktop ? {} : styles.tableContainerMobile}
-                >
-                  {isDesktop ? (
-                    <AggregatedPracticeTable
-                      title="Aggregated positions"
-                      data={practice1Stats}
-                    />
-                  ) : (
-                    <AggregatedPracticeMobileTable
-                      title="Aggregated positions"
-                      data={practice1Stats}
-                    />
-                  )}
-
-                  <ActualPracticeTable
-                    title="Actual positions"
-                    data={practice1ActualStats}
+              <TableContainer
+                sx={isDesktop ? {} : styles.tableContainerMobile}
+              >
+                {isDesktop ? (
+                  <AggregatedPracticeTable
+                    title="Aggregated positions"
+                    data={practice1Stats}
                   />
-                </TableContainer>
-              )}
-            </PracticeContainer>
+                ) : (
+                  <AggregatedPracticeMobileTable
+                    title="Aggregated positions"
+                    data={practice1Stats}
+                  />
+                )}
 
-            <PracticeContainer>
+                <ActualPracticeTable
+                  title="Actual positions"
+                  data={practice1ActualStats}
+                />
+              </TableContainer>
+            </PracticeContainer>)}
+
+            {practice2Stats.length > 0 && (<PracticeContainer>
               <PracticeTitle>Practice 2</PracticeTitle>
 
               {Object.keys(practice2TimePeriod).length > 0 && (
@@ -362,13 +361,6 @@ const PracticeStats = () => {
 
               {practice2Weather.length > 0 && (
                 <PracticeWeather practiceWeather={practice2Weather} />
-              )}
-
-              {practiceStatsLoading && (
-                <LinearProgress
-                  color="secondary"
-                  sx={styles.circularProgress}
-                />
               )}
 
               {practice2Stats.length > 0 && (
@@ -393,9 +385,9 @@ const PracticeStats = () => {
                   />
                 </TableContainer>
               )}
-            </PracticeContainer>
+            </PracticeContainer>)}
 
-            <PracticeContainer>
+            {practice3Stats.length > 0 && (<PracticeContainer>
               <PracticeTitle>Practice 3</PracticeTitle>
 
               {Object.keys(practice3TimePeriod).length > 0 && (
@@ -404,13 +396,6 @@ const PracticeStats = () => {
 
               {practice3Weather.length > 0 && (
                 <PracticeWeather practiceWeather={practice3Weather} />
-              )}
-
-              {practiceStatsLoading && (
-                <LinearProgress
-                  color="secondary"
-                  sx={styles.circularProgress}
-                />
               )}
 
               {practice3Stats.length > 0 && (
@@ -435,8 +420,8 @@ const PracticeStats = () => {
                   />
                 </TableContainer>
               )}
-            </PracticeContainer>
-          </>
+            </PracticeContainer>)}
+          </>)
         )}
       </ParentContainer>
     </Layout>


### PR DESCRIPTION
Hello, I hope I find you well!

Your project is really cool!

In this pull request, I changed a little the PracticeStats component, so practices won't show if it didn't happen (a sprint weekend, for example).
Before:
![image](https://github.com/despolov/f1-stats/assets/87719561/58cb1e15-7c4f-416f-80c6-111a1ed4bb84)
After:
![image](https://github.com/despolov/f1-stats/assets/87719561/3accd0a9-06a7-43fc-8c55-ddd1bf630565)

And now, instead of showing each practice session loading, it says 

> "Loading practice stats..."

![image](https://github.com/despolov/f1-stats/assets/87719561/a413342b-e8b0-4ff7-ad08-05931171ee1a)

I hope you like this small changes and, again, I really loved your project!

Thank you!